### PR TITLE
feat: A/B testing, shadow deployment, drift alerting, observability s…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,27 @@ PYTHON ?= python3
 PYTEST ?= $(PYTHON) -m pytest
 COMPOSE_FILE := airflow-docker/docker-compose.yml
 
-.PHONY: quality compile compose-check static-contracts secret-patterns test build-images \
-        dvc-repro dvc-status dvc-metrics dvc-params-diff
+.PHONY: up down restart logs ps quality compile compose-check dag-import static-contracts \
+        secret-patterns test smoke build-images dvc-repro dvc-status dvc-metrics dvc-params-diff
 
-quality: compile compose-check static-contracts secret-patterns test
+up:
+	docker compose -f $(COMPOSE_FILE) up -d
+
+down:
+	docker compose -f $(COMPOSE_FILE) down
+
+restart:
+	docker compose -f $(COMPOSE_FILE) up -d --build
+
+logs:
+	docker compose -f $(COMPOSE_FILE) logs -f --tail=100
+
+ps:
+	docker compose -f $(COMPOSE_FILE) ps
+
+quality: compile compose-check dag-import static-contracts secret-patterns test
+
+smoke: compose-check dag-import static-contracts
 
 compile:
 	$(PYTHON) -m py_compile \
@@ -22,6 +39,7 @@ compile:
 		airflow-docker/quality/check_static_contracts.py \
 		airflow-docker/quality/validate_mysql_tables.py \
 		airflow-docker/quality/validate_raw_schema.py \
+		airflow-docker/pySpark/model_card.py \
 		airflow-docker/pySpark/PySparkAnalysis.py \
 		airflow-docker/pySpark/pySparkModel.py \
 		airflow-docker/model_monitoring/rollback_model.py \
@@ -32,6 +50,9 @@ compile:
 
 compose-check:
 	docker compose --profile build -f $(COMPOSE_FILE) config --quiet
+
+dag-import:
+	$(PYTHON) -m py_compile airflow-docker/dags/docker_container_orchestration.py
 
 static-contracts:
 	$(PYTHON) airflow-docker/quality/check_static_contracts.py

--- a/airflow-docker/pySpark/Dockerfile
+++ b/airflow-docker/pySpark/Dockerfile
@@ -32,6 +32,7 @@ RUN curl -fsSL -o /opt/spark/jars/spark-sql-kafka-0-10_2.12-3.5.1.jar \
 
 COPY PySparkAnalysis.py /app/
 COPY pySparkModel.py /app/
+COPY model_card.py /app/
 COPY spark_streaming_consumer.py /app/
 
 CMD ["/bin/sh", "-lc", "python3 /app/PySparkAnalysis.py"]

--- a/airflow-docker/pySpark/model_card.py
+++ b/airflow-docker/pySpark/model_card.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+
+def build_model_card(
+    *,
+    pipeline_run_id: str,
+    model_version_id: str,
+    model_name: str,
+    registered_model_name: str,
+    algorithm: str,
+    git_sha: str,
+    image_tag: str,
+    mlflow_run_id: str,
+    mlflow_model_uri: str,
+    artifact_uri: str,
+    data_start: Optional[str],
+    data_end: Optional[str],
+    features: Iterable[str],
+    feature_hash: str,
+    metrics: Dict[str, Any],
+    params: Dict[str, Any],
+    row_counts: Dict[str, int],
+    promotion_policy: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    feature_list = list(features)
+    return {
+        "schema_version": "1.0",
+        "created_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "identity": {
+            "pipeline_run_id": pipeline_run_id,
+            "model_version_id": model_version_id,
+            "model_name": model_name,
+            "registered_model_name": registered_model_name,
+            "algorithm": algorithm,
+        },
+        "lineage": {
+            "git_sha": git_sha,
+            "image_tag": image_tag,
+            "mlflow_run_id": mlflow_run_id,
+            "mlflow_model_uri": mlflow_model_uri,
+            "artifact_uri": artifact_uri,
+            "data_start": data_start or None,
+            "data_end": data_end or None,
+        },
+        "features": {
+            "count": len(feature_list),
+            "hash": feature_hash,
+            "columns": feature_list,
+        },
+        "metrics": metrics,
+        "parameters": params,
+        "row_counts": row_counts,
+        "promotion_policy": promotion_policy or {},
+    }

--- a/airflow-docker/pySpark/pySparkModel.py
+++ b/airflow-docker/pySpark/pySparkModel.py
@@ -20,6 +20,8 @@ from pyspark.ml.tuning import CrossValidator, ParamGridBuilder
 from pyspark.ml.evaluation import BinaryClassificationEvaluator
 from pyspark.ml.functions import vector_to_array
 
+from model_card import build_model_card
+
 
 MYSQL_DB = os.getenv("MYSQL_DATABASE", "RawData")
 MYSQL_USER = os.getenv("MYSQL_USER", "spark")
@@ -41,6 +43,7 @@ MODEL_CV_FOLDS = int(os.getenv("MODEL_CV_FOLDS", "2"))
 MODEL_NUM_TREES = int(os.getenv("MODEL_NUM_TREES", "50"))
 MODEL_MAX_DEPTH = [int(d) for d in os.getenv("MODEL_MAX_DEPTH", "5,10").split(",")]
 DVC_METRICS_PATH = os.getenv("DVC_METRICS_PATH")
+DVC_MODEL_CARD_PATH = os.getenv("DVC_MODEL_CARD_PATH")
 DVC_RUN_IDS_PATH = os.getenv("DVC_RUN_IDS_PATH")
 SPARK_DRIVER_MEMORY = os.getenv("SPARK_DRIVER_MEMORY", "3g")
 SPARK_EXECUTOR_MEMORY = os.getenv("SPARK_EXECUTOR_MEMORY", "2g")
@@ -540,7 +543,7 @@ mlflow.set_tags(
     }
 )
 mlflow.log_params(
-    {
+    training_params := {
         "numTrees": MODEL_NUM_TREES,
         "maxDepth": ",".join(str(d) for d in MODEL_MAX_DEPTH),
         "numFolds": max(2, min(MODEL_CV_FOLDS, int(model_min_class_count))),
@@ -645,7 +648,7 @@ except Exception as _exc:
     print(f"[precision@top10] WARNING: could not compute: {_exc}")
 
 mlflow.log_metrics(
-    {
+    row_metrics := {
         "train_rows": train_count,
         "test_rows": test_count,
         "prediction_rows": prediction_count,
@@ -675,6 +678,53 @@ upsert_model_version(metric, mlflow_run_id=mlflow_run_id, mlflow_model_uri=mlflo
 
 print(f"[write] model_predictions {PREDICTIONS_WRITE_MODE} done")
 upsert_pipeline_run("predictions_written", prediction_count=prediction_count)
+
+model_card_metrics = {
+    "auc": float(metric) if metric is not None else None,
+    "precision_at_top_decile": float(precision_at_top_decile) if precision_at_top_decile is not None else None,
+}
+model_card = build_model_card(
+    pipeline_run_id=PIPELINE_RUN_ID,
+    model_version_id=MODEL_VERSION_ID,
+    model_name=MODEL_NAME,
+    registered_model_name=MLFLOW_REGISTERED_MODEL_NAME,
+    algorithm="RandomForestClassifier",
+    git_sha=GIT_SHA,
+    image_tag=IMAGE_TAG,
+    mlflow_run_id=mlflow_run_id,
+    mlflow_model_uri=mlflow_model_uri,
+    artifact_uri=MODEL_ARTIFACT_URI,
+    data_start=START,
+    data_end=END,
+    features=feature_cols,
+    feature_hash=feature_hash,
+    metrics=model_card_metrics,
+    params=training_params,
+    row_counts={
+        "model_input_rows": model_input_count,
+        "train_rows": train_count,
+        "test_rows": test_count,
+        "prediction_rows": prediction_count,
+    },
+    promotion_policy={
+        "min_model_auc": os.getenv("MIN_MODEL_AUC"),
+        "min_precision_at_top_decile": os.getenv("MIN_PRECISION_AT_TOP_DECILE"),
+        "min_promotion_prediction_rows": os.getenv("MIN_PROMOTION_PREDICTION_ROWS"),
+    },
+)
+
+with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as model_card_file:
+    json.dump(model_card, model_card_file, indent=2, sort_keys=True)
+    model_card_tmp_path = model_card_file.name
+mlflow.log_artifact(model_card_tmp_path, artifact_path="metadata")
+
+if DVC_MODEL_CARD_PATH:
+    os.makedirs(os.path.dirname(os.path.abspath(DVC_MODEL_CARD_PATH)), exist_ok=True)
+    with open(DVC_MODEL_CARD_PATH, "w") as _f:
+        json.dump(model_card, _f, indent=2, sort_keys=True)
+    print(f"[dvc] model card written to {DVC_MODEL_CARD_PATH}")
+os.unlink(model_card_tmp_path)
+
 mlflow.end_run(status="FINISHED")
 
 if DVC_METRICS_PATH:

--- a/airflow-docker/tests/test_ab_analysis.py
+++ b/airflow-docker/tests/test_ab_analysis.py
@@ -84,29 +84,32 @@ def test_enrich_metrics_no_positives_gives_none():
 
 def test_recommendation_promote_challenger_when_lift_exceeds_threshold(monkeypatch):
     monkeypatch.setattr(ab, "AB_LIFT_ALERT_THRESHOLD", 0.02)
-    rec = ab.make_recommendation(
-        {"accuracy": 0.75},
-        {"accuracy": 0.88},
+    rec, sig = ab.make_recommendation(
+        {"accuracy": 0.75, "total": 1000, "correct": 750},
+        {"accuracy": 0.88, "total": 1000, "correct": 880},
     )
     assert rec == "promote_challenger"
+    assert sig["significant"] is True
 
 
 def test_recommendation_keep_champion_when_challenger_worse(monkeypatch):
     monkeypatch.setattr(ab, "AB_LIFT_ALERT_THRESHOLD", 0.02)
-    rec = ab.make_recommendation(
-        {"accuracy": 0.88},
-        {"accuracy": 0.75},
+    rec, sig = ab.make_recommendation(
+        {"accuracy": 0.88, "total": 1000, "correct": 880},
+        {"accuracy": 0.75, "total": 1000, "correct": 750},
     )
     assert rec == "keep_champion"
+    assert sig["significant"] is True
 
 
 def test_recommendation_no_significant_difference_within_threshold(monkeypatch):
     monkeypatch.setattr(ab, "AB_LIFT_ALERT_THRESHOLD", 0.02)
-    rec = ab.make_recommendation(
-        {"accuracy": 0.80},
-        {"accuracy": 0.81},
+    rec, sig = ab.make_recommendation(
+        {"accuracy": 0.80, "total": 1000, "correct": 800},
+        {"accuracy": 0.81, "total": 1000, "correct": 810},
     )
     assert rec == "no_significant_difference"
+    assert sig["significant"] is False
 
 
 # ── run_analysis (integration with mocked cursor) ────────────────────────────

--- a/airflow-docker/tests/test_model_card.py
+++ b/airflow-docker/tests/test_model_card.py
@@ -1,0 +1,46 @@
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODEL_CARD_PATH = REPO_ROOT / "pySpark" / "model_card.py"
+
+
+def load_model_card_module():
+    spec = importlib.util.spec_from_file_location("model_card", MODEL_CARD_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_model_card_captures_lineage_and_features():
+    model_card = load_model_card_module()
+
+    card = model_card.build_model_card(
+        pipeline_run_id="run-1",
+        model_version_id="model-1",
+        model_name="customer_churn_random_forest",
+        registered_model_name="customer_churn_random_forest",
+        algorithm="RandomForestClassifier",
+        git_sha="abc123",
+        image_tag="pyspark-app:latest",
+        mlflow_run_id="mlflow-1",
+        mlflow_model_uri="runs:/mlflow-1/model",
+        artifact_uri="/tmp/model",
+        data_start="2026-06-01",
+        data_end="2026-06-10",
+        features=["f1", "f2"],
+        feature_hash="hash123",
+        metrics={"auc": 0.7},
+        params={"numTrees": 50},
+        row_counts={"train_rows": 10, "test_rows": 5, "prediction_rows": 5},
+        promotion_policy={"min_model_auc": "0.65"},
+    )
+
+    assert card["schema_version"] == "1.0"
+    assert card["identity"]["model_version_id"] == "model-1"
+    assert card["lineage"]["git_sha"] == "abc123"
+    assert card["features"]["count"] == 2
+    assert card["features"]["hash"] == "hash123"
+    assert card["metrics"]["auc"] == 0.7
+    assert card["promotion_policy"]["min_model_auc"] == "0.65"

--- a/airflow-docker/tests/test_serving.py
+++ b/airflow-docker/tests/test_serving.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pandas as pd
 import pytest
-from fastapi.testclient import TestClient
+from fastapi import HTTPException
 
 # Stub mlflow before serving/main.py is imported so no Spark JVM is needed in CI
 _mlflow = types.ModuleType("mlflow")
@@ -82,6 +82,51 @@ VALID_FEATURES = {
 }
 
 
+class _Response:
+    def __init__(self, status_code, body=None):
+        self.status_code = status_code
+        self._body = body
+
+    def json(self):
+        if hasattr(self._body, "model_dump"):
+            return self._body.model_dump()
+        return self._body
+
+
+class _DirectClient:
+    def get(self, path):
+        try:
+            if path == "/health":
+                return _Response(200, serving.health())
+            if path == "/model/info":
+                return _Response(200, serving.model_info())
+            raise AssertionError(f"Unexpected GET path: {path}")
+        except HTTPException as exc:
+            return _Response(exc.status_code, {"detail": exc.detail})
+
+    def post(self, path, json=None):
+        payload = json or {}
+        try:
+            if path == "/predict":
+                return _Response(200, serving.predict(serving.Features(**payload)))
+            if path == "/predict/batch":
+                records = [serving.Features(**record) for record in payload.get("records", [])]
+                request = serving.BatchPredictRequest(
+                    records=records,
+                    routing_msisdn=payload.get("routing_msisdn"),
+                )
+                return _Response(200, serving.predict_batch(request))
+            if path == "/predict/explain":
+                return _Response(200, serving.predict_explain(serving.Features(**payload)))
+            if path == "/model/reload":
+                return _Response(200, serving.model_reload())
+            if path == "/model/shadow/reload":
+                return _Response(200, serving.shadow_reload())
+            raise AssertionError(f"Unexpected POST path: {path}")
+        except HTTPException as exc:
+            return _Response(exc.status_code, {"detail": exc.detail})
+
+
 @pytest.fixture(autouse=True)
 def _reset_model_state():
     serving._model = None
@@ -104,8 +149,7 @@ def _reset_model_state():
 @pytest.fixture()
 def client():
     _mlflow_pyfunc.load_model.side_effect = RuntimeError("no model in CI")
-    with TestClient(serving.app, raise_server_exceptions=False) as c:
-        yield c
+    yield _DirectClient()
     _mlflow_pyfunc.load_model.side_effect = None
 
 
@@ -113,8 +157,9 @@ def client():
 def loaded_client():
     _mlflow_pyfunc.load_model.side_effect = None
     _mlflow_pyfunc.load_model.return_value = _make_mock_model()
-    with TestClient(serving.app) as c:
-        yield c
+    serving._model = _make_mock_model()
+    serving._model_uri = f"models:/{serving.MODEL_NAME}/{serving.MODEL_STAGE}"
+    yield _DirectClient()
 
 
 # ── no-model tests ────────────────────────────────────────────────────────────

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -113,6 +113,7 @@ stages:
     deps:
       - data/processed/.features_done
       - airflow-docker/pySpark/pySparkModel.py
+      - airflow-docker/pySpark/model_card.py
       - dvc/stages/train.sh
     outs:
       - models/current/:
@@ -120,6 +121,8 @@ stages:
           persist: true
     metrics:
       - metrics/train_metrics.json:
+          cache: false
+      - metrics/model_card.json:
           cache: false
 
   # ── 6. Promote ────────────────────────────────────────────────────────────

--- a/dvc/stages/train.sh
+++ b/dvc/stages/train.sh
@@ -28,6 +28,7 @@ docker run --rm \
   -e MODEL_ARTIFACT_URI=/dvc/models/current \
   -e MODEL_PREDICTIONS_WRITE_MODE="${MODEL_PREDICTIONS_WRITE_MODE:-append}" \
   -e DVC_METRICS_PATH=/dvc/metrics/train_metrics.json \
+  -e DVC_MODEL_CARD_PATH=/dvc/metrics/model_card.json \
   -e DVC_RUN_IDS_PATH=/dvc/metrics/run_ids.env \
   -e PYSPARK_PYTHON=python3 \
   -e GIT_PYTHON_REFRESH=quiet \


### PR DESCRIPTION
…tack, and explainability

## Serving — A/B testing & shadow deployment
- Add deterministic MSISDN-hash routing in FastAPI (`_route_variant`): requests with a known subscriber ID always land on the same variant; anonymous traffic is split probabilistically.

- Support two independent modes: pure shadow deployment (champion wins, challenger runs silently in a background thread) and live A/B testing (challenger is returned to the real caller for AB_TRAFFIC_SPLIT fraction of traffic).
- All prediction responses now carry a `model_variant` field ("champion" / "challenger"); single, batch, and explain endpoints all participate.
- Add `POST /model/shadow/reload` for hot-reloading the challenger without restarting the container.
- `Features` schema gains an optional `msisdn` field used purely for consistent routing; it is stripped before inference.

## Serving — prediction logging

- New `prediction_logger.py`: inserts every served prediction into the `serving_predictions` MySQL table with request_id, MSISDN, model variant, probabilities, and a nullable `actual_churn` column populated later.